### PR TITLE
Use Reverse Rotationsort by default

### DIFF
--- a/src/Data/Tensort/Robustsort.hs
+++ b/src/Data/Tensort/Robustsort.hs
@@ -14,8 +14,8 @@ import Data.Tensort.Subalgorithms.Bubblesort (bubblesort)
 import Data.Tensort.Subalgorithms.Magicsort (magicsort)
 import Data.Tensort.Subalgorithms.Permutationsort (permutationsort)
 import Data.Tensort.Subalgorithms.Rotationsort
-  ( rotationsort,
-    rotationsortAmbi,
+  ( rotationsortAmbi,
+    rotationsortReverse,
     rotationsortReverseAmbi,
   )
 import Data.Tensort.Subalgorithms.Supersort
@@ -36,7 +36,7 @@ robustsortP = tensort (mkTsProps 3 supersortP)
 supersortP :: Sortable -> Sortable
 supersortP =
   supersort
-    ( rotationsort,
+    ( rotationsortReverse,
       bubblesort,
       permutationsort,
       mundaneSuperStrat
@@ -49,7 +49,13 @@ robustsortB :: Sortable -> Sortable
 robustsortB = tensort (mkTsProps 3 supersortB)
 
 supersortB :: Sortable -> Sortable
-supersortB = supersort (rotationsort, bubblesort, bogosort, mundaneSuperStrat)
+supersortB =
+  supersort
+    ( rotationsortReverse,
+      bubblesort,
+      bogosort,
+      mundaneSuperStrat
+    )
 
 robustsortRM :: Sortable -> Sortable
 robustsortRM = robustsortRCustom robustsortM
@@ -58,7 +64,13 @@ robustsortM :: Sortable -> Sortable
 robustsortM = tensort (mkTsProps 3 supersortM)
 
 supersortM :: Sortable -> Sortable
-supersortM = supersort (rotationsortAmbi, rotationsortReverseAmbi, magicsort, magicSuperStrat)
+supersortM =
+  supersort
+    ( rotationsortReverseAmbi,
+      rotationsortAmbi,
+      magicsort,
+      magicSuperStrat
+    )
 
 robustsortRCustom :: SortAlg -> Sortable -> Sortable
 robustsortRCustom baseSortAlg xs =
@@ -85,4 +97,9 @@ robustsortRecursive bytesize baseSortAlg
   -- will use the baseSortAlg (which by default is a standard version of
   -- Robustsort with a bytesize of 3) to sort its records.
   | bytesize <= 27 = baseSortAlg
-  | otherwise = tensort (mkTsProps (getLn bytesize) (robustsortRecursive (getLn bytesize) baseSortAlg))
+  | otherwise =
+      tensort
+        ( mkTsProps
+            (getLn bytesize)
+            (robustsortRecursive (getLn bytesize) baseSortAlg)
+        )


### PR DESCRIPTION
Do this because Reverse Rotationsort is more accurate than forward Rotationsort